### PR TITLE
Updater endpoint

### DIFF
--- a/lib/backends/backend.js
+++ b/lib/backends/backend.js
@@ -6,6 +6,7 @@ var destroy = require('destroy');
 var LRU = require('lru-diskcache');
 var streamRes = require('stream-res');
 var Buffer = require('buffer').Buffer;
+var streamToString = require('stream-to-string');
 
 function Backend(nuts, opts) {
     this.cacheId = 0;
@@ -82,6 +83,47 @@ Backend.prototype.serveAsset = function(asset, req, res) {
             // Send the stream to the user
             outputStream(stream)
         ]);
+    });
+};
+
+Backend.prototype.getAssetSha2 = function(realAsset) {
+    if ( null === realAsset.sha2 ) {
+      return Q.Promise.resolve(null);
+    }
+
+    var that = this;
+    var asset = {
+      id: String(realAsset.sha2.id),
+      raw: realAsset.sha2,
+    };
+    var cacheKey = asset.id;
+
+    function processStream(stream) {
+        return streamToString(stream)
+          .then(function(data) {
+            return data.trim();
+          });
+    }
+
+    // Key exists
+    if (that.cache.has(cacheKey)) {
+        return that.cache.getStream(cacheKey)
+            .then(processStream);
+    }
+
+    return that.getAssetStream(asset)
+    .then(function(stream) {
+        return Q.all([
+            // Cache the stream
+            that.cache.set(cacheKey, stream),
+
+            // Send the stream to the user
+            processStream(stream)
+        ])
+        // Eliminate cache id
+        .then(function(res) {
+          return res[1];
+        });
     });
 };
 

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -68,7 +68,7 @@ function Nuts(opts) {
 
     this.router.get('/notes/:version?', this.onServeNotes);
 
-    this.router.get('/electron-updater/:channel/latest-mac.json', this.onElectronUpdateMac);
+    this.router.get('/electron-updater/:channel/latest-mac.yml', this.onElectronUpdateMac);
     this.router.get('/electron-updater/:channel/latest.yml', this.onElectronUpdateWindows);
 
     // Bind API
@@ -295,10 +295,10 @@ Nuts.prototype.onElectronUpdate = function(channel, platform, filetype) {
       })
       .then(function(sha2) {
         return {
-          "version": channelObj.latest,
-          "releaseDate": channelObj.published_at,
-          "url": url,
-          "sha2": sha2,
+          path: url,
+          version: channelObj.latest,
+          sha2: sha2,
+          releaseDate: channelObj.published_at
         };
       });
     });
@@ -306,29 +306,16 @@ Nuts.prototype.onElectronUpdate = function(channel, platform, filetype) {
 
 // Electron Updater used by OSX (latest-mac.json)
 Nuts.prototype.onElectronUpdateMac = function(req, res, next) {
-  var gitFilePath = '../../../';
-  var fullUrl = getFullUrl(req);
   return this.onElectronUpdate(req.params.channel, platforms.OSX, 'zip')
-    .then(function(data) {
-      return Object.assign(data, {
-        url: urljoin(fullUrl, gitFilePath, data.url),
-        sha2: undefined,
-      });
-    })
     .then(function(v) { return JSON.parse(JSON.stringify(v)) })
-    .then(function(data) { return res.status(200).send(data) })
+    .then(function(latestObject) {
+      return res.status(200).type('text/vnd.yaml').send(YAML.stringify(latestObject));
+    })
     .fail(next);
 };
 
 Nuts.prototype.onElectronUpdateWindows = function(req, res, next) {
   return this.onElectronUpdate(req.params.channel, platforms.WINDOWS)
-    .then(function(data) {
-      return {
-        path: data.url,
-        version: data.version,
-        sha2: data.sha2,
-      };
-    })
     .then(function(v) { return JSON.parse(JSON.stringify(v)) })
     .then(function(latestObject) {
       return res.status(200).type('text/vnd.yaml').send(YAML.stringify(latestObject));

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -240,7 +240,6 @@ Nuts.prototype.onUpdate = function(req, res, next) {
             notesSlice = [versions[0]];
         }
         var releaseNotes = notes.merge(notesSlice, { includeTag: false });
-        console.error(latest.tag);
         var gitFilePath = (channel === '*' ? '/../../../' : '/../../../../../');
         res.status(200).send({
             "url": urljoin(fullUrl, gitFilePath, '/download/version/'+latest.tag+'/'+platform+'?filetype='+filetype),
@@ -279,12 +278,29 @@ Nuts.prototype.onElectronUpdate = function(channel, platform, filetype) {
         url += '?filetype='+filetype;
       }
 
-      return {
-        "version": channelObj.latest,
-        "releaseDate": channelObj.published_at,
-        "url": url,
-        "sha2": 'xxxxx', // TODO
-      };
+      return that.versions.resolve({
+          channel: channel,
+          platform: platform,
+          tag: channelObj.tag,
+      })
+      .then(function(version) {
+          var asset = platforms.resolve(version, platform, {
+            wanted: filetype? '.'+filetype : null
+          });
+
+          if (!asset) throw new Error("No download available for platform "+platform+" for version "+version.tag+" ("+channel+")");
+
+          // Call analytic middleware, then serve
+          return that.backend.getAssetSha2(asset);
+      })
+      .then(function(sha2) {
+        return {
+          "version": channelObj.latest,
+          "releaseDate": channelObj.published_at,
+          "url": url,
+          "sha2": sha2,
+        };
+      });
     });
 };
 
@@ -293,24 +309,28 @@ Nuts.prototype.onElectronUpdateMac = function(req, res, next) {
   var gitFilePath = '../../../';
   var fullUrl = getFullUrl(req);
   return this.onElectronUpdate(req.params.channel, platforms.OSX, 'zip')
-    .then((data) => Object.assign(data, {
-      url: urljoin(fullUrl, gitFilePath, data.url),
-      sha2: undefined,
-    }))
-    .then((v) => JSON.parse(JSON.stringify(v)))
-    .then((data) => res.status(200).send(data))
+    .then(function(data) {
+      return Object.assign(data, {
+        url: urljoin(fullUrl, gitFilePath, data.url),
+        sha2: undefined,
+      });
+    })
+    .then(function(v) { return JSON.parse(JSON.stringify(v)) })
+    .then(function(data) { return res.status(200).send(data) })
     .fail(next);
 };
 
 Nuts.prototype.onElectronUpdateWindows = function(req, res, next) {
   return this.onElectronUpdate(req.params.channel, platforms.WINDOWS)
-    .then((data) => ({
-      path: data.url,
-      version: data.version,
-      sha2: data.sha2,
-    }))
-    .then((v) => JSON.parse(JSON.stringify(v)))
-    .then((latestObject) => {
+    .then(function(data) {
+      return {
+        path: data.url,
+        version: data.version,
+        sha2: data.sha2,
+      };
+    })
+    .then(function(v) { return JSON.parse(JSON.stringify(v)) })
+    .then(function(latestObject) {
       return res.status(200).type('text/vnd.yaml').send(YAML.stringify(latestObject));
     })
     .fail(next);

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -70,6 +70,7 @@ function Nuts(opts) {
 
     this.router.get('/electron-updater/:channel/latest-mac.yml', this.onElectronUpdateMac);
     this.router.get('/electron-updater/:channel/latest.yml', this.onElectronUpdateWindows);
+    this.router.get('/electron-updater/:channel/:filename', this.onDownload);
 
     // Bind API
     this.router.use('/api', this.onAPIAccessControl);
@@ -269,17 +270,6 @@ Nuts.prototype.onElectronUpdate = function(channel, platform, filetype) {
       return channels[channel];
     })
     .then(function(channelObj) {
-      var relativePath = '../../';
-      var url = [
-        'download/channel',
-        channel,
-        platform,
-      ].join('/');
-      if (filetype) {
-        url += '?filetype='+filetype;
-      }
-      var path = relativePath + url;
-
       return that.versions.resolve({
           channel: channel,
           platform: platform,
@@ -293,15 +283,19 @@ Nuts.prototype.onElectronUpdate = function(channel, platform, filetype) {
           if (!asset) throw new Error("No download available for platform "+platform+" for version "+version.tag+" ("+channel+")");
 
           // Call analytic middleware, then serve
-          return that.backend.getAssetSha2(asset);
+          return that.backend.getAssetSha2(asset)
+          .then(function(sha2) {
+            return {
+              path: asset.raw.name,
+              sha2: sha2,
+            };
+          });
       })
-      .then(function(sha2) {
-        return {
-          path: path,
+      .then(function(fileInfo) {
+        return Object.assign({
           version: channelObj.latest,
-          sha2: sha2,
           releaseDate: channelObj.published_at
-        };
+        }, fileInfo);
       });
     });
 };

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -283,6 +283,7 @@ Nuts.prototype.onElectronUpdate = function(channel, platform, filetype) {
         "version": channelObj.latest,
         "releaseDate": channelObj.published_at,
         "url": url,
+        "sha2": 'xxxxx', // TODO
       };
     });
 };
@@ -294,20 +295,22 @@ Nuts.prototype.onElectronUpdateMac = function(req, res, next) {
   return this.onElectronUpdate(req.params.channel, platforms.OSX, 'zip')
     .then((data) => Object.assign(data, {
       url: urljoin(fullUrl, gitFilePath, data.url),
+      sha2: undefined,
     }))
+    .then((v) => JSON.parse(JSON.stringify(v)))
     .then((data) => res.status(200).send(data))
     .fail(next);
 };
 
 Nuts.prototype.onElectronUpdateWindows = function(req, res, next) {
   return this.onElectronUpdate(req.params.channel, platforms.WINDOWS)
-    .then((data) => {
-      const latestObject = {
-        path: data.url,
-        version: data.version,
-        sha512: 'xxxxx', // TODO
-      }
-
+    .then((data) => ({
+      path: data.url,
+      version: data.version,
+      sha2: data.sha2,
+    }))
+    .then((v) => JSON.parse(JSON.stringify(v)))
+    .then((latestObject) => {
       return res.status(200).type('text/vnd.yaml').send(YAML.stringify(latestObject));
     })
     .fail(next);

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -282,7 +282,7 @@ Nuts.prototype.onElectronUpdate = function(channel, platform, filetype) {
 
           if (!asset) throw new Error("No download available for platform "+platform+" for version "+version.tag+" ("+channel+")");
 
-          // Call analytic middleware, then serve
+          // Extract sha2 file content and append with asset name.
           return that.backend.getAssetSha2(asset)
           .then(function(sha2) {
             return {

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -269,6 +269,7 @@ Nuts.prototype.onElectronUpdate = function(channel, platform, filetype) {
       return channels[channel];
     })
     .then(function(channelObj) {
+      var relativePath = '../../';
       var url = [
         'download/channel',
         channel,
@@ -277,6 +278,7 @@ Nuts.prototype.onElectronUpdate = function(channel, platform, filetype) {
       if (filetype) {
         url += '?filetype='+filetype;
       }
+      var path = relativePath + url;
 
       return that.versions.resolve({
           channel: channel,
@@ -295,7 +297,7 @@ Nuts.prototype.onElectronUpdate = function(channel, platform, filetype) {
       })
       .then(function(sha2) {
         return {
-          path: url,
+          path: path,
           version: channelObj.latest,
           sha2: sha2,
           releaseDate: channelObj.published_at

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -273,7 +273,6 @@ Nuts.prototype.onElectronUpdate = function(channel, platform, filetype) {
       return that.versions.resolve({
           channel: channel,
           platform: platform,
-          tag: channelObj.tag,
       })
       .then(function(version) {
           var asset = platforms.resolve(version, platform, {
@@ -286,16 +285,12 @@ Nuts.prototype.onElectronUpdate = function(channel, platform, filetype) {
           return that.backend.getAssetSha2(asset)
           .then(function(sha2) {
             return {
+              version: version.tag,
+              releaseDate: version.published_at,
               path: asset.raw.name,
               sha2: sha2,
             };
           });
-      })
-      .then(function(fileInfo) {
-        return Object.assign({
-          version: channelObj.latest,
-          releaseDate: channelObj.published_at
-        }, fileInfo);
       });
     });
 };

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -12,6 +12,7 @@ var notes = require('./utils/notes');
 var platforms = require('./utils/platforms');
 var winReleases = require('./utils/win-releases');
 var API_METHODS = require('./api');
+var YAML = require('yamljs');
 
 function getFullUrl(req) {
     return req.protocol + '://' + req.get('host') + req.originalUrl;
@@ -67,6 +68,9 @@ function Nuts(opts) {
 
     this.router.get('/notes/:version?', this.onServeNotes);
 
+    this.router.get('/electron-updater/:channel/latest-mac.json', this.onElectronUpdateMac);
+    this.router.get('/electron-updater/:channel/latest.yml', this.onElectronUpdateWindows);
+
     // Bind API
     this.router.use('/api', this.onAPIAccessControl);
     _.each(API_METHODS, function(method, route) {
@@ -94,7 +98,6 @@ Nuts.prototype._init = function() {
         return that.versions.list();
     });
 }
-
 
 // Perform a hook using promised functions
 Nuts.prototype.performQ = function(name, arg, fn) {
@@ -194,7 +197,6 @@ Nuts.prototype.onDownload = function(req, res, next) {
     .fail(next);
 };
 
-
 // Request to update
 Nuts.prototype.onUpdateRedirect = function(req, res, next) {
     Q()
@@ -246,6 +248,67 @@ Nuts.prototype.onUpdate = function(req, res, next) {
             "notes": releaseNotes,
             "pub_date": latest.published_at.toISOString()
         });
+    })
+    .fail(next);
+};
+
+Nuts.prototype.onElectronUpdate = function(channel, platform, filetype) {
+    var that = this;
+
+    return Q()
+    .then(function() {
+        if (!platform) throw new Error('Requires "platform" parameter');
+
+        platform = platforms.detect(platform);
+        return that.versions.channels();
+    })
+    .then(function(channels) {
+        if ( !channel || false === channels.hasOwnProperty(channel) ) {
+          throw new Error('Invalid update channel');
+        }
+
+      return channels[channel];
+    })
+    .then(function(channelObj) {
+      var url = [
+        'download/channel',
+        channel,
+        platform,
+      ].join('/');
+      if (filetype) {
+        url += '?filetype='+filetype;
+      }
+
+      return {
+        "version": channelObj.latest,
+        "releaseDate": channelObj.published_at,
+        "url": url,
+      };
+    });
+};
+
+// Electron Updater used by OSX (latest-mac.json)
+Nuts.prototype.onElectronUpdateMac = function(req, res, next) {
+  var gitFilePath = '../../../';
+  var fullUrl = getFullUrl(req);
+  return this.onElectronUpdate(req.params.channel, platforms.OSX, 'zip')
+    .then((data) => Object.assign(data, {
+      url: urljoin(fullUrl, gitFilePath, data.url),
+    }))
+    .then((data) => res.status(200).send(data))
+    .fail(next);
+};
+
+Nuts.prototype.onElectronUpdateWindows = function(req, res, next) {
+  return this.onElectronUpdate(req.params.channel, platforms.WINDOWS)
+    .then((data) => {
+      const latestObject = {
+        path: data.url,
+        version: data.version,
+        sha512: 'xxxxx', // TODO
+      }
+
+      return res.status(200).type('text/vnd.yaml').send(YAML.stringify(latestObject));
     })
     .fail(next);
 };
@@ -389,6 +452,5 @@ Nuts.prototype.onAPIAccessControl = function(req, res, next) {
         next();
     }, next);
 };
-
 
 module.exports = Nuts;

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -1,6 +1,7 @@
 var _ = require('lodash');
 var Q = require('q');
 var semver = require('semver');
+var path = require('path');
 
 var platforms = require('./utils/platforms');
 
@@ -24,10 +25,27 @@ function normalizeVersion(release) {
     if (release.draft) return null;
 
     var downloadCount = 0;
-    var releasePlatforms = _.chain(release.assets)
+    var shaFiles = {};
+
+    var releaseAssets = _.chain(release.assets)
+        .map(function(asset) {
+          if ( asset.name.endsWith('.sha2') ) {
+            Object.assign(shaFiles, {
+              [path.basename(asset.name, '.sha2')]: asset,
+            });
+            return null;
+          }
+
+          return asset;
+        })
+        .compact()
+        .value();
+
+    var releasePlatforms = _.chain(releaseAssets)
         .map(function(asset) {
             var platform = platforms.detect(asset.name);
             if (!platform) return null;
+            var sha2 = shaFiles[asset.name] || null;
 
             downloadCount = downloadCount + asset.download_count;
             return {
@@ -36,6 +54,7 @@ function normalizeVersion(release) {
                 filename: asset.name,
                 size: asset.size,
                 content_type: asset.content_type,
+                sha2,
                 raw: asset
             };
         })

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -59,6 +59,12 @@ function compareVersions(v1, v2) {
     if (semver.lt(v1.tag, v2.tag)) {
         return 1;
     }
+    if (v1.published_at  > v2.published_at) {
+      return -1;
+    }
+    if (v1.published_at  < v2.published_at) {
+      return 1;
+    }
     return 0;
 }
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "request": "2.60.0",
     "semver": "5.0.1",
     "stream-res": "1.0.1",
+    "stream-to-string": "^1.1.0",
     "strip-bom": "2.0.0",
     "understudy": "4.1.0",
     "urljoin.js": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "strip-bom": "2.0.0",
     "understudy": "4.1.0",
     "urljoin.js": "0.1.0",
-    "uuid": "2.0.1"
+    "uuid": "2.0.1",
+    "yamljs": "^0.2.10"
   },
   "devDependencies": {
     "mocha": "1.18.2",


### PR DESCRIPTION
Implements `/electron-updater/:channel` endpoint to use with `electron-updater` package.
NOTE:
  - each nsis installer should have .sha2 asset with the same name.

I want to keep it like open until it works on production,
then we will rearrange this and open PR against upstream