### PR TITLE
fix(download): keep request platform even if filename was set

### DIFF
--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -152,20 +152,14 @@ Nuts.prototype.onDownload = function(req, res, next) {
     var filename = req.params.filename;
     var filetypeWanted = req.query.filetype;
 
-    // When serving a specific file, platform is not required
-    if (!filename) {
-        // Detect platform from useragent
-        if (!platform) {
-            if (req.useragent.isMac) platform = platforms.OSX;
-            if (req.useragent.isWindows) platform = platforms.WINDOWS;
-            if (req.useragent.isLinux) platform = platforms.LINUX;
-            if (req.useragent.isLinux64) platform = platforms.LINUX_64;
-        }
-
-        if (!platform) return next(new Error('No platform specified and impossible to detect one'));
-    } else {
-        platform = null;
+    if (!platform) {
+      if (req.useragent.isMac) platform = platforms.OSX;
+      if (req.useragent.isWindows) platform = platforms.WINDOWS;
+      if (req.useragent.isLinux) platform = platforms.LINUX;
+      if (req.useragent.isLinux64) platform = platforms.LINUX_64;
     }
+
+    if (!platform) return next(new Error('No platform specified and impossible to detect one'));
 
     // If specific version, don't enforce a channel
     if (tag != 'latest') channel = '*';


### PR DESCRIPTION
there was a bug that happens only if we had release with only 1 platform type (For example, mac is 5 minutes faster then windows, so mac artifact was released but windows not yet).

because platform is nullified from request, then the resolve function will resolve latest, and won't find the filename in there.
in this fix we will keep platform so when we resolve version it will get latest for that specific platform.